### PR TITLE
Exception handling

### DIFF
--- a/ILIASSoapConnector/Exceptions/ILSoapException.cs
+++ b/ILIASSoapConnector/Exceptions/ILSoapException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ILIASSoapConnector.Exceptions
+{
+	public class ILSoapException : Exception
+	{
+		public ILSoapException(string message): base(message)
+		{
+
+		}
+	}
+}

--- a/ILIASSoapConnector/Exceptions/ILSoapException.cs
+++ b/ILIASSoapConnector/Exceptions/ILSoapException.cs
@@ -6,9 +6,14 @@ namespace ILIASSoapConnector.Exceptions
 {
 	public class ILSoapException : Exception
 	{
-		public ILSoapException(string message): base(message)
-		{
+		public string FaultCode { get; }
 
+		public string FaultError { get; set; }
+
+		public ILSoapException(string message, string faultCode, string faultError): base(message)
+		{
+			FaultCode = faultCode;
+			FaultError = faultError;
 		}
 	}
 }

--- a/ILIASSoapConnector/ILIASSoapConnector.csproj
+++ b/ILIASSoapConnector/ILIASSoapConnector.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Models\" />
     <Folder Include="Parser\" />
   </ItemGroup>
 

--- a/ILIASSoapConnector/ILWebRequest.cs
+++ b/ILIASSoapConnector/ILWebRequest.cs
@@ -41,10 +41,18 @@ namespace ILIASSoapConnector
 				//For many possible errors ILIAS returns an HTTP 500 error that throws an exception. 
 				//In order to know what happens we have to intercept the error and read the content.
 				var response = await ReadStreamAsync(e.Response);
-				var errorMessage = IliasToObjectParser.ErrorResponse(response);
-				throw new ILSoapException(errorMessage);
+				try
+				{
+					var errorMessage = IliasToObjectParser.ErrorResponse(response);
+					throw new ILSoapException(e.Message, errorMessage.FaultCode, errorMessage.FaultString);
+				}
+				catch (Exception)
+				{
+					//If we cannot parse the error there is another problem. 
+					//In this case we throw the original exception.
+					throw e;
+				}
 			}
-			
 		}
 
 

--- a/ILIASSoapConnector/Models/SoapFault.cs
+++ b/ILIASSoapConnector/Models/SoapFault.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ILIASSoapConnector.Models
+{
+	public class SoapFault
+	{
+		public string FaultCode { get; }
+
+		public string FaultString { get; }
+
+		public SoapFault(string faultCode, string faultString)
+		{
+			FaultCode = faultCode;
+			FaultString = faultString;
+		}
+	}
+}

--- a/ILIASSoapConnector/Parser/IliasToObjectParser.cs
+++ b/ILIASSoapConnector/Parser/IliasToObjectParser.cs
@@ -63,11 +63,16 @@ namespace ILIASSoapConnector.Parser
         /// </summary>
         /// <param name="xml"></param>
         /// <returns>Ilias SessionId</returns>
-        public static string ErrorResponse(string xml)
+        public static SoapFault ErrorResponse(string xml)
         {
+            XNamespace soapEnv = "http://schemas.xmlsoap.org/soap/envelope/";
+
             XDocument doc = XDocument.Parse(xml);
-            var e = doc.Root.Value;
-            return e;
+            XElement fault = doc.Descendants().Where(x => x.Name.LocalName == "Fault").FirstOrDefault();
+            var faultCode = fault.Element("faultcode").Value;
+            var faultString = fault.Element("faultstring").Value;
+
+            return new SoapFault(faultCode, faultString);
         }
 
         /// <summary>

--- a/ILIASSoapConnector/Parser/IliasToObjectParser.cs
+++ b/ILIASSoapConnector/Parser/IliasToObjectParser.cs
@@ -59,6 +59,18 @@ namespace ILIASSoapConnector.Parser
         }
 
         /// <summary>
+        /// Parst die XML-Antwort im Falle eines Server Error.
+        /// </summary>
+        /// <param name="xml"></param>
+        /// <returns>Ilias SessionId</returns>
+        public static string ErrorResponse(string xml)
+        {
+            XDocument doc = XDocument.Parse(xml);
+            var e = doc.Root.Value;
+            return e;
+        }
+
+        /// <summary>
         /// Parst die XML-Antwort von SOAP - loginUser().
         /// </summary>
         /// <param name="xml"></param>


### PR DESCRIPTION
Since ILIAS produces a server error when many errors occur we intercept the excpetion and examine it to see if a status message is included. If a status message is contained we throw a separate exception with the status message.